### PR TITLE
refactor: rename githubToken to otelToken in otel-cicd-action usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,4 @@ jobs:
         with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
-          otlpAuthorization: ${{ secrets.OTLP_AUTH_TOKEN }}
-          otelToken: ${{ secrets.OTEL_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,20 @@ jobs:
           notification_message: 'The build workflow has failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           notification_priority: 5
 
+  otel:
+    permissions:
+      contents: read # Required. To access the private repository
+      actions: read # Required. To read workflow runs
+      pull-requests: read # Optional. To read PR labels
+      checks: read # Optional. To read run annotations
+    if: always()
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Export workflow
+        uses: corentinmusard/otel-cicd-action@v4
+        with:
+          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          otelToken: ${{ secrets.OTEL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag martynvandijke/soundbridgefx:latest
       - name: Push Docker image
+        if: github.event_name != 'pull_request'
         run: docker push martynvandijke/soundbridgefx:latest
 
       - name: Gotify Success Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,5 @@ jobs:
         with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          otlpAuthorization: ${{ secrets.OTLP_AUTH_TOKEN }}
           otelToken: ${{ secrets.OTEL_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build . --file Dockerfile --tag test-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build . --file Dockerfile --tag test-build
+  otel:
+    permissions:
+      contents: read # Required. To access the private repository
+      actions: read # Required. To read workflow runs
+      pull-requests: read # Optional. To read PR labels
+      checks: read # Optional. To read run annotations
+    if: always()
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    needs: [docker-build]
+    steps:
+      - name: Export workflow
+        uses: corentinmusard/otel-cicd-action@v4
+        with:
+          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          otelToken: ${{ secrets.OTEL_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
         with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          otlpAuthorization: ${{ secrets.OTLP_AUTH_TOKEN }}
           otelToken: ${{ secrets.OTEL_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,4 @@ jobs:
         with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
-          otlpAuthorization: ${{ secrets.OTLP_AUTH_TOKEN }}
-          otelToken: ${{ secrets.OTEL_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Rename the githubToken input parameter to otelToken and the secret ref from secrets.GITHUB_TOKEN to secrets.OTEL_TOKEN across all workflows using corentinmusard/otel-cicd-action.